### PR TITLE
General a front-end action URL instead of a CP action URL

### DIFF
--- a/dump/templates/_settings.html
+++ b/dump/templates/_settings.html
@@ -22,8 +22,8 @@
 
 <h3>Template</h3>
 
-<code>{{ "{{ actionUrl('dump/backup', { key: '" ~ key ~ "' }) }}"|raw }}</code>
+<code>{{ "{{ siteUrl(craft.config.get('actionTrigger') ~ '/dump/backup', { key: '" ~ key ~ "' }) }}"|raw }}</code>
 
 <h3>URL</h3>
 
-<code>{{ actionUrl('dump/backup', { key: key }) }}</code>
+<code>{{ siteUrl(craft.config.get('actionTrigger') ~ '/dump/backup', { key: key }) }}</code>


### PR DESCRIPTION
So that anonymous front-end action requests will go through.  Fixes https://github.com/putyourlightson/Craft-Dump/issues/2
