### PR TITLE
added ability to save a copy of backup to remote assets sources

### DIFF
--- a/dump/DumpPlugin.php
+++ b/dump/DumpPlugin.php
@@ -28,14 +28,42 @@ class DumpPlugin extends BasePlugin
     {
         return array(
             'key' => array(AttributeType::String, 'required' => true),
-	        'revisions' => array(AttributeType::String),
+	          'revisions' => array(AttributeType::String),
+            'folderId' => array(AttributeType::String)
         );
     }
 
     public function getSettingsHtml()
     {
-        return craft()->templates->render('dump/_settings', array(
-            'settings' => $this->getSettings()
-        ));
+      $sourceIds = craft()->assetSources->getAllSourceIds();
+      $tree = craft()->assets->getFolderTreeBySourceIds($sourceIds);
+
+      return craft()->templates->render('dump/_settings', array(
+          'settings' => $this->getSettings(),
+          'tree' => $tree
+      ));
+    }
+
+    public function init() {
+
+      craft()->on('db.onBackup', function(Event $event) {
+
+
+
+        $plugin = craft()->plugins->getPlugin('dump');
+        $settings = $plugin->getSettings();
+
+        $folderId = $settings->folderId;
+
+
+
+        if ($folderId > 0) {
+
+          $segments = explode("/", $event->params['filePath']);
+          $filename = array_pop($segments);
+          $response = craft()->assets->insertFileByLocalPath($event->params['filePath'], $filename, $folderId);
+        }
+
+      });
     }
 }

--- a/dump/controllers/DumpController.php
+++ b/dump/controllers/DumpController.php
@@ -14,6 +14,12 @@ class DumpController extends BaseController
      */
     public function actionBackup()
     {
+
+      //DumpPlugin::log('started dump', LogLevel::Error);
+
+
+
+
         // check if plugin is installed
         if (!$plugin = craft()->plugins->getPlugin('dump'))
         {
@@ -32,11 +38,17 @@ class DumpController extends BaseController
             die('Unauthorised key');
         }
 
-	    // Delete old backups if required
-	    $filesDeleted = $this->_deleteOldBackups($settings->revisions);
+
+        //DumpPlugin::log('ran backup');
+
+	      // Delete old backups if required
+	      $filesDeleted = craft()->dump->deleteOldBackups($settings->revisions, $settings->folderId);
+
 
         // run backup
-        craft()->db->backup();
+        $backup = craft()->db->backup();
+
+
 
         // check if a redirect was posted
         if (craft()->request->getPost('redirect'))
@@ -47,42 +59,4 @@ class DumpController extends BaseController
         die('Success. Removed ' . $filesDeleted . ' old backups');
     }
 
-	/**
-	 * Delete old backups
-     *
-	 * @param int $revisions
-	 * @return int
-	 */
-	private function _deleteOldBackups($revisions = null)
-	{
-		// If a number is not passed return
-		if (!is_numeric($revisions))
-        {
-			return 0;
-		}
-
-    	$backupPath = craft()->path->getDbBackupPath();
-
-		// Get a list of files in the backup directory and sort by descending order
-		if ($files = scandir($backupPath, SCANDIR_SORT_DESCENDING))
-        {
-			// Remove 'x' from the beginning of the array
-			$files = array_slice($files, ($revisions - 1));
-			$i = 0;
-
-			// Loop through any remaining files and delete them
-			foreach($files as $file)
-            {
-				$filePath = $backupPath . $file;
-
-				if (is_file($filePath))
-                {
-					unlink($filePath);
-					$i++;
-				}
-			}
-
-			return $i;
-		}
-	}
 }

--- a/dump/services/DumpService.php
+++ b/dump/services/DumpService.php
@@ -1,0 +1,77 @@
+<?php
+namespace Craft;
+
+class DumpService extends BaseApplicationComponent {
+
+
+  public function deleteOldBackups($revisions = null, $folderId = 0)
+  {
+
+    // If a number is not passed return
+    if (!is_numeric($revisions))
+    {
+      return 0;
+    }
+
+    $backupPath = craft()->path->getDbBackupPath();
+
+    $i = 0;
+
+    // Get a list of files in the backup directory and sort by descending order
+    if ($files = scandir($backupPath, SCANDIR_SORT_DESCENDING))
+    {
+      // Remove 'x' from the beginning of the array
+      $files = array_slice($files, ($revisions - 1));
+
+
+      // Loop through any remaining files and delete them
+      foreach($files as $file)
+      {
+        $filePath = $backupPath . $file;
+
+        if (is_file($filePath))
+        {
+          unlink($filePath);
+          $i++;
+        }
+      }
+
+    }
+
+    // if there backups are saving to assets, cleanup those as well
+    if ($folderId > 0)
+    {
+
+      $backups = $this->getFilesByFolderId($folderId);
+
+      // Remove 'x' from the beginning of the array
+      $extraBackups = array_slice($backups, ($revisions - 1));
+
+      // create an array based on the ids from those backups
+      $extraBackupIds = array_map(create_function('$b', 'return $b->id;'), $extraBackups);
+
+      // delete those extra files no matter where they are
+      craft()->assets->deleteFiles($extraBackupIds);
+
+    }
+
+    return $i;
+  }
+
+  private function getFilesByFolderId($folderId, $indexBy = null)
+  {
+    $files = craft()->db->createCommand()
+      ->select('fi.*')
+      ->from('assetfiles fi')
+      ->join('assetfolders fo', 'fo.id = fi.folderId')
+      ->where('fo.id = :folderId', array(':folderId' => $folderId))
+      ->order('fi.dateCreated desc')
+      ->queryAll();
+
+    return AssetFileModel::populateModels($files, $indexBy);
+  }
+
+
+
+
+}

--- a/dump/templates/_settings.html
+++ b/dump/templates/_settings.html
@@ -1,6 +1,5 @@
 {% import "_includes/forms" as forms %}
 
-
 {{ forms.textField({
     label: "Key"|t,
     id: 'key',
@@ -10,6 +9,30 @@
     autofocus: true,
     errors: settings.getErrors('key')
 }) }}
+
+<div class="field">
+  <div class="heading">
+    <label for="settings-key">Assets Folder</label>
+    <div class="instructions">
+      <p>Select the assets folder to copy the backup into (works great with S3 or google cloud sources for an offsite backup).</p>
+    </div>
+  </div>
+  <select name="folderId">
+
+    <option value="0">
+      Dont save into assets
+    </option>
+    {% for folder in tree %}
+
+    <option value="{{folder.id}}" {% if settings.folderId == folder.id %} selected{% endif %}>
+      {{ folder.name}}
+    </option>
+
+    {% endfor %}
+  </select>
+</div>
+
+
 
 {{ forms.textField({
     label: "Old backups to keep"|t,


### PR DESCRIPTION
Hey Ben,

We've been using your plugin for a while and we added the ability to save a copy of the backup to an asset source.  The big advantage of this is if you create an Amazon S3, Rackspace or Google Cloud source and select that as the asset folder to save your backups it gives you a nice simple offsite backup system.

I'm using the new 'db.onBackup' hook to power this functionality and the built in craft()->assets->insertFileByLocalPath() service method to handle all the hard work of saving the file.

Curious to hear what you think and thanks again for getting this plugin started, I'm excited to see it continue to grow as a lightweight backup solution build mostly existing craft services.
