### PR TITLE
revised method of saving backups to assets sources

### DIFF
--- a/dump/DumpPlugin.php
+++ b/dump/DumpPlugin.php
@@ -27,7 +27,8 @@ class DumpPlugin extends BasePlugin
     protected function defineSettings()
     {
         return array(
-            'key' => array(AttributeType::String, 'required' => true),
+            'key'       => array(AttributeType::String, 'required' => true),
+            'source'    => array(AttributeType::String, 'required' => true),
 	        'revisions' => array(AttributeType::String),
         );
     }

--- a/dump/controllers/DumpController.php
+++ b/dump/controllers/DumpController.php
@@ -35,8 +35,18 @@ class DumpController extends BaseController
 	    // Delete old backups if required
 	    $filesDeleted = $this->_deleteOldBackups($settings->revisions);
 
-        // run backup
-        craft()->db->backup();
+        // run backup and capture the URL
+        $url = craft()->db->backup();
+
+        // create temporary file
+        $temp = tempnam('/tmp', 'DB_');
+
+        // copy data from backup into the temporary file
+        $data = file_get_contents($url);
+        file_put_contents($temp, $data);
+
+        // place the tempoarary file into designated asset source, using '.txt' since '.sql' is not an accepted format
+        craft()->assets->insertFileByLocalPath($temp, basename($url) . '.txt', $settings->source);
 
         // check if a redirect was posted
         if (craft()->request->getPost('redirect'))
@@ -44,7 +54,7 @@ class DumpController extends BaseController
             $this->redirectToPostedUrl();
         }
 
-        die('Success. Removed ' . $filesDeleted . ' old backups');
+        Craft::dd('Success. Removed ' . $filesDeleted . ' old backups');
     }
 
 	/**

--- a/dump/templates/_settings.html
+++ b/dump/templates/_settings.html
@@ -1,6 +1,5 @@
 {% import "_includes/forms" as forms %}
 
-
 {{ forms.textField({
     label: "Key"|t,
     id: 'key',
@@ -9,6 +8,15 @@
     value: settings.key,
     autofocus: true,
     errors: settings.getErrors('key')
+}) }}
+
+{{ forms.select({
+    label: "Assets Folder"|t,
+    id: "source",
+    name: "source",
+    instructions: "Select the assets folder to copy the backup into (works great with S3 or Google Cloud Storage sources for offsite backup)."|t,
+    options: craft.dump.getAllSources,
+    value: settings.source
 }) }}
 
 {{ forms.textField({

--- a/dump/variables/DumpVariable.php
+++ b/dump/variables/DumpVariable.php
@@ -1,0 +1,26 @@
+<?php
+namespace Craft;
+
+class DumpVariable
+{
+    function getAllSources()
+    {
+    	$allSources = craft()->assetSources->getAllSources();
+    	$object = array();
+
+        // A custom built array is necessary, since Craft's
+        // field-forms require keys not available in the
+        // arrays of the assets object
+    	foreach ($allSources as $source)
+    	{
+    		$data = array(
+    			'label' => $source->name,
+    			'value' => $source->id
+    		);
+
+    		array_push($object, $data);
+    	}
+
+        return $object;
+    }
+}


### PR DESCRIPTION
I noticed the discussion on this from about a year ago.  Since I also had a need to save backups remotely, I added the capability, but did it in a very simple way that fits neatly with your established code base as you had asked _keithmancuso_.

I actually downloaded the plugin, thinking this was already included due to the screenshot you have posted on https://www.putyourlightson.net/craft-dump.  It would be nice for future downloaders if this could be included in your plugin.